### PR TITLE
Support UUID keys in translation entries

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -73,12 +73,9 @@ Hooks.once("init", () => {
             user: User
         ) {
             const result = await wrapped(documentClass, context, user);
-            if (!game.babele || !game.babele.initialized) {
-                return result;
-            }
             const { pack, options } = context;
 
-            if (!pack || !result || !game.babele.isTranslated(pack)) {
+            if (!pack || !game.babele.isTranslated(pack)) {
                 return result;
             }
 
@@ -86,7 +83,13 @@ Hooks.once("init", () => {
                 return game.babele.translateIndex(result as CompendiumIndexData[], pack);
             } else {
                 return result.map((data) => {
-                    return documentClass.fromSource(game.babele.translate(pack, data.toObject()), { pack });
+                    const source = data.toObject();
+                    // Work around some documents not having a sourceId flag
+                    // The uuid property will be filtered out by the DataModel after translation
+                    if (!source.flags?.core?.sourceId) {
+                        source.uuid = (data as ClientDocument).uuid;
+                    }
+                    return documentClass.fromSource(game.babele.translate(pack, source), { pack });
                 });
             }
         },

--- a/src/modules/babele/types.ts
+++ b/src/modules/babele/types.ts
@@ -23,7 +23,7 @@ interface Translation {
      *  The value can be a Converter object which describes what converter should be used for that field.
      *  If no mapping is provided a default mapping is used based on document type.
      */
-    mapping?: Record<string, string | DynamicMapping>;
+    mapping?: Mapping;
     /**
      * The entries come in two different variants that I have seen so far:
      * 1. { [OriginalName]: { [propertyMapping]: value }, ...}
@@ -59,6 +59,9 @@ type TranslatableData = CompendiumIndexData & {
     hasTranslation?: boolean;
     originalName?: string;
     flags?: {
+        core?: {
+            sourceId?: CompendiumUUID;
+        };
         babele?: {
             translated: boolean;
             hasTranslation: boolean;

--- a/src/modules/dialogs/on-demand-translation.ts
+++ b/src/modules/dialogs/on-demand-translation.ts
@@ -42,7 +42,7 @@ class OnDemandTranslationDialog extends Dialog {
 
                             const pack = game.babele.packs.find((pack) => pack.translated && pack.hasTranslation(data));
                             if (pack) {
-                                const translatedData = pack.translate(data, true);
+                                const translatedData = pack.translate(data, { translationsOnly: true });
                                 if (!translatedData) continue;
                                 updates.push(mergeObject(translatedData, { _id: item.id }));
                                 area.append(`${data.name.padEnd(68, ".")}ok\n`);

--- a/src/modules/mapping/compendium-mapping.ts
+++ b/src/modules/mapping/compendium-mapping.ts
@@ -30,7 +30,7 @@ class CompendiumMapping {
         return this.fields.filter((f) => !f.isDynamic).reduce((m, f) => mergeObject(m, f.extract(data)), {});
     }
 
-    /** If one of the mapped field is dynamic, the compendium is considered dynamic. */
+    /** If one of the mapped field is dynamic, the compendium is considered dynamic */
     isDynamic(): boolean {
         return this.fields.some((f) => f.isDynamic);
     }


### PR DESCRIPTION
Either the key of the object or the `id` property can be UUIDs

Also changes `TranslatedCompendium#translations` to a `Map` and adds a `TranslatedCompendium#translationsObject` getter to retrieve the map as an object.