### PR TITLE
Prefer lookup by source UUID instead of name if possible

### DIFF
--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -18,4 +18,9 @@ function JSONstringifyOrder(obj: object): string {
     return `${newJson}\n`;
 }
 
-export { JSONstringifyOrder };
+function collectionFromMetadata(metadata: CompendiumMetadata): string {
+    const collectionPrefix = metadata.packageType === "world" ? "world" : metadata.packageName;
+    return `${collectionPrefix}.${metadata.name}`;
+}
+
+export { collectionFromMetadata, JSONstringifyOrder };

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,2 +1,2 @@
-export { JSONstringifyOrder } from "./helpers.ts";
-export { appendHeaderButton } from "./dom.ts";
+export * from "./helpers.ts";
+export * from "./dom.ts";


### PR DESCRIPTION
Also restores `flags` property in compendium index to accommodate some translation modules.