### PR TITLE
Support custom mappings in module registration data

### DIFF
--- a/src/modules/babele/types.ts
+++ b/src/modules/babele/types.ts
@@ -1,3 +1,5 @@
+import { DocumentType } from "./values.ts";
+
 interface DynamicMapping {
     /** A converter that was registered in this.converters */
     converter: string;
@@ -12,6 +14,7 @@ type TranslationEntry = Record<string, TranslationEntryData>;
 type CompendiumTranslations = Record<string, TranslationEntry>;
 
 interface Translation {
+    module?: BabeleModule;
     /** The collection name  */
     collection: string;
     /** The translated name of the compendium pack */
@@ -43,6 +46,7 @@ interface BabeleModule {
     dir: string;
     lang: string;
     module: string;
+    customMappings?: Record<Partial<DocumentType>, Record<string, string | DynamicMapping>>;
     /** Priority of this translation. Baseline is 100. If multiple translations are loaded the highest priority is used. */
     priority: number;
 }

--- a/src/modules/converters/converters.ts
+++ b/src/modules/converters/converters.ts
@@ -48,7 +48,7 @@ class Converters {
                 const pack = game.babele.packs.find(
                     (pack) => pack.translated && pack.documentType === documentType && pack.hasTranslation(data)
                 );
-                return pack ? (pack.translate(data) as TranslatableData) : data;
+                return pack ? pack.translate(data) : data;
             })
         );
     }
@@ -56,12 +56,12 @@ class Converters {
     static mappedField(field: string) {
         return function (
             _documents: TranslatableData[],
-            translations: CompendiumTranslations | string,
+            translation: CompendiumTranslations | string,
             data: TranslatableData,
             tc?: TranslatedCompendium
         ): unknown {
-            if (typeof translations === "string") {
-                return translations;
+            if (typeof translation === "string") {
+                return translation;
             }
             return tc?.translateField(field, data);
         };

--- a/src/modules/translated-compendium/translated-compendium.ts
+++ b/src/modules/translated-compendium/translated-compendium.ts
@@ -1,6 +1,6 @@
-import { TranslatableData, Translation, TranslationEntry } from "@modules/babele/types.ts";
+import type { TranslatableData, Translation, TranslationEntry } from "@modules/babele/types.ts";
+import type { DocumentType } from "@modules/babele/values.ts";
 import { CompendiumMapping } from "@modules";
-import { DocumentType } from "@modules/babele/values.ts";
 import { collectionFromMetadata } from "@util";
 
 class TranslatedCompendium {
@@ -13,7 +13,9 @@ class TranslatedCompendium {
 
     constructor(metadata: CompendiumMetadata, translations?: Translation) {
         this.metadata = metadata;
-        this.mapping = new CompendiumMapping(metadata.type, translations?.mapping ?? null, this);
+        const moduleMapping = translations?.module?.customMappings?.[metadata.type];
+        const mappings = translations?.mapping ?? moduleMapping ?? null;
+        this.mapping = new CompendiumMapping(metadata.type, mappings, this);
 
         if (translations) {
             mergeObject(metadata, { label: translations.label });


### PR DESCRIPTION
Specific mappings in the translation file take precedence over mappings registered with a module.

```js
    Babele.get().register({
      module: "pf2e_compendium_chn",
      lang: "cn",
      dir: "compendium",
      customMappings: {
        Actor: {
          name: "name",
          portrait: {
            path: "img",
            converter: "npc-portrait-path"
          },
          token: {
            path: "prototypeToken",
            converter: "npc-token-translation"
          },
          data: {
            path: "system",
            converter: "npc-data-translation"
          },
          items: {
            path: "items",
            converter: "npc-item-translation"
          },
          publicNotes: "system.details.publicNotes",
          allSaves: "system.attributes.allSaves.value",
          senses: "system.traits.senses.value",
          hp: "system.attributes.hp.details",
          hazarddisable: "system.details.disable",
          hazarddescription: "system.details.description",
          hazardreset: "system.details.reset",
          hazardroutine: "system.details.routine"
        }
      },
    });
  