### PR TITLE
Remove zip support in favor of storing loaded translations in a local `IndexedDB`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.0.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
-                "@zip.js/zip.js": "^2.7.32",
+                "dexie": "^3.2.4",
                 "remeda": "^1.33.0"
             },
             "devDependencies": {
@@ -1120,16 +1120,6 @@
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
             "dev": true
         },
-        "node_modules/@zip.js/zip.js": {
-            "version": "2.7.32",
-            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.32.tgz",
-            "integrity": "sha512-9Ox1meDIvIKE23LLA7Fxd/ewJpKjj2KryH92doHRqx2406LmIzorsiMawL0qIK7dvwN9K+mfk47lauoIE0o1zQ==",
-            "engines": {
-                "bun": ">=0.7.0",
-                "deno": ">=1.0.0",
-                "node": ">=16.5.0"
-            }
-        },
         "node_modules/acorn": {
             "version": "8.11.2",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
@@ -1497,6 +1487,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/dexie": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/dexie/-/dexie-3.2.4.tgz",
+            "integrity": "sha512-VKoTQRSv7+RnffpOJ3Dh6ozknBqzWw/F3iqMdsZg958R0AS8AnY9x9d1lbwENr0gzeGJHXKcGhAMRaqys6SxqA==",
+            "engines": {
+                "node": ">=6.0"
             }
         },
         "node_modules/dir-glob": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "vite-tsconfig-paths": "^4.2.2"
     },
     "dependencies": {
-        "@zip.js/zip.js": "^2.7.32",
+        "dexie": "^3.2.4",
         "remeda": "^1.33.0"
     }
 }

--- a/src/module/babele/types.ts
+++ b/src/module/babele/types.ts
@@ -59,8 +59,8 @@ interface Translation {
 
 /** A module that prvoides translations */
 interface BabeleModule {
-    /** Directory containing the translation JSON files. */
-    dir: string;
+    /** Directories containing the translation JSON files */
+    dir: string[];
     /** The supported language */
     lang: string;
     /** The module name */
@@ -68,10 +68,13 @@ interface BabeleModule {
     /** Custom mappings that are applied to all packs of a given type */
     customMappings?: Record<Partial<SupportedType>, Record<string, string | DynamicMapping>>;
     /** Priority of this translation. Baseline is 100. Translations are merged by priority
-     *  where lower priority is overwritten by higher priority*/
+     *  where lower priority is overwritten by higher priority */
     priority: number;
-    /** A zip file that contains the translation JSON files. Uses the `dir` options as base path */
-    zipFile?: string;
+}
+
+/** Data with the old directory format */
+interface MaybeOldModuleData extends Omit<BabeleModule, "dir"> {
+    dir: string | string[];
 }
 
 /** A catch-all type for data that can be translated with Babele. Double translation info is required
@@ -98,6 +101,7 @@ export type {
     CompendiumTranslations,
     DynamicMapping,
     Mapping,
+    MaybeOldModuleData,
     SupportedType,
     TranslatableData,
     Translation,

--- a/src/module/storage/database.ts
+++ b/src/module/storage/database.ts
@@ -1,0 +1,115 @@
+import { Dexie, type Table } from "dexie";
+import { BabeleModule, Translation } from "@module/babele/types.ts";
+
+class BabeleDB extends Dexie {
+    /** The module data table */
+    declare modules: Table<StoredModule, number>;
+    /** A list of active modules for the current language */
+    #modules: BabeleModule[];
+
+    constructor(modules?: BabeleModule[]) {
+        super("BabeleDB");
+        this.version(1).stores({
+            modules: "++id, name",
+        });
+        this.#modules = modules ?? [];
+    }
+
+    /** Deletes all stored data */
+    static async clear(): Promise<void> {
+        const db = new this();
+        try {
+            if (!db.isOpen) {
+                await db.open();
+            }
+            await db.modules.clear();
+            db.close();
+            console.log("Babele: All stored translations were successfully deleted from the database.");
+        } catch (e) {
+            if (e instanceof Error) {
+                console.error(`Failed to clear database: ${e.stack || e}`);
+            }
+        }
+    }
+
+    /** Gets module data from the DB if the module version is still the same */
+    async getModuleData(moduleName: string): Promise<StoredModule | null> {
+        const currentVersion = this.#getModuleVersion(moduleName);
+        if (!currentVersion) return null;
+        const data = await this.modules.where("name").equals(moduleName).first();
+        if (!data) return null;
+
+        if (data.version !== currentVersion) {
+            await this.modules.delete(data.id!);
+            console.log(`Babele: Version mismatch for module "${moduleName}". The database entry was deleted.`);
+            return null;
+        }
+        console.log(`Babele: Loaded database entry for module: ${moduleName}.`);
+        for (const translation of data.translations) {
+            console.log(`Babele: Retrieved translation for: ${translation.collection}.`);
+        }
+        return data;
+    }
+
+    /** Saves module data to the DB */
+    async saveModuleData(moduleName: string, translations: Translation[]): Promise<void> {
+        const currentVersion = this.#getModuleVersion(moduleName);
+        if (!currentVersion) return;
+
+        const existing = await this.modules.where("name").equals(moduleName).first();
+        if (existing) {
+            await this.modules.update(existing.id!, {
+                translations: existing.translations.concat(translations),
+                worlds: [...new Set(existing.worlds.concat(game.world.id))],
+            });
+        } else {
+            await this.modules.put({
+                name: moduleName,
+                translations,
+                version: currentVersion,
+                worlds: [game.world.id],
+            });
+        }
+
+        console.log(`Babele: Translations from module "${moduleName}" were saved to the local database.`);
+    }
+
+    /** Removes DB entries of modules that are no longer active */
+    async cleanUp(): Promise<void> {
+        const toDelete: number[] = [];
+        await this.modules.each((stored) => {
+            if (stored.worlds.includes(game.world.id) && !this.#modules.find((m) => m.module === stored.name)) {
+                toDelete.push(stored.id!);
+                console.log(`Bable: Deleting database entry for missing module: ${stored.name}.`);
+            }
+        });
+        if (toDelete.length > 0) {
+            return this.modules.bulkDelete(toDelete);
+        }
+    }
+
+    /** Returns the version of a specific module by name */
+    #getModuleVersion(moduleName: string): string | null {
+        const version = game.modules.get(moduleName)?.version;
+        if (!version) {
+            console.error(`Babele: Could not find version for module "${moduleName}"!`);
+            return null;
+        }
+        return version;
+    }
+}
+
+interface StoredModule {
+    /** Auto-incremented database id */
+    id?: number;
+    /** The module name */
+    name: string;
+    /** Translation data from this module */
+    translations: Translation[];
+    /** The module version */
+    version: string;
+    /** An array of world ids where this module is active */
+    worlds: string[];
+}
+
+export { BabeleDB };

--- a/src/module/storage/index.ts
+++ b/src/module/storage/index.ts
@@ -1,0 +1,2 @@
+export * from "./database.ts";
+export * from "./loader.ts";

--- a/src/module/storage/loader.ts
+++ b/src/module/storage/loader.ts
@@ -1,0 +1,198 @@
+import { BabeleModule, Translation } from "@module/babele/types.ts";
+import { isSupportedType } from "@util";
+import { BabeleDB } from "./database.ts";
+
+/** Handles loading the available translations either from the local
+ *  IndexedDB or from the server
+ */
+class BabeleLoader {
+    /** A Dexie instance */
+    #db: BabeleDB;
+    /** The currently set user language */
+    #lang: string;
+    /** System provided translations */
+    #systemTranslationsDir: string | null = null;
+    /** A list of active modules for the current language */
+    #modules: BabeleModule[];
+    /** A convenience accessor for module priority */
+    #priorities = new Map<string, number>();
+    /** A map of translations grouped by priority */
+    #priorityMap = new Map<number, Translation[]>();
+    /** A list of all files that were loaded */
+    #allFiles: string[] = [];
+
+    constructor({ lang, modules, systemTranslationsDir }: BabeleLoaderParams) {
+        this.#systemTranslationsDir = systemTranslationsDir;
+        this.#lang = lang;
+        this.#modules = modules;
+        for (const mod of modules) {
+            this.#priorities.set(mod.module, mod.priority);
+        }
+        this.#db = new BabeleDB(modules);
+    }
+
+    /** Loads translations from the local DB or from the server */
+    async loadTranslations(): Promise<Map<number, Translation[]> | null> {
+        if (!this.#db.isOpen) {
+            try {
+                await this.#db.open();
+            } catch (e) {
+                if (e instanceof Error) {
+                    console.error(`Failed to open Database: ${e.stack || e}`);
+                }
+            }
+        }
+        await this.#db.cleanUp();
+        this.#priorityMap.clear();
+
+        const babeleDirectory = game.settings.get("babele", "directory");
+        const directories: Promise<{ name?: string; translations: Translation[] }>[] = [];
+        const trimmed = babeleDirectory?.trim?.();
+        if (trimmed) {
+            directories.push(this.#loadFromDirectory({ directory: trimmed, priority: 100 }));
+        }
+        if (this.#systemTranslationsDir) {
+            directories.push(
+                this.#loadFromDirectory({
+                    directory: `systems/${game.system.id}/${this.#systemTranslationsDir}/${this.#lang}`,
+                    priority: 100,
+                }),
+            );
+        }
+
+        for (const mod of this.#modules) {
+            const name = mod.module;
+            const dbData = await this.#db.getModuleData(name);
+            if (dbData) {
+                const priority = this.#priorities.get(name) ?? 100;
+                this.#addToPriorityMap(priority, dbData.translations);
+                continue;
+            }
+            for (const dir of mod.dir) {
+                directories.push(
+                    this.#loadFromDirectory({
+                        directory: `modules/${mod.module}/${dir}`,
+                        moduleName: name,
+                        priority: mod.priority,
+                    }),
+                );
+            }
+        }
+
+        // Process indiviual files
+        if (directories.length > 0) {
+            const results = await Promise.all(directories);
+            for (const result of results) {
+                if (!result.name) continue;
+                await this.#db.saveModuleData(result.name, result.translations);
+            }
+
+            // Set the world setting for users that don't have file browse permissions
+            if (game.user.isGM) {
+                game.settings.set("babele", "translationFiles", this.#allFiles);
+            }
+        }
+        this.#db.close();
+
+        const total = [...this.#priorityMap.values()].reduce(
+            (cnt: number, current: Translation[]) => (cnt += current.length),
+            0,
+        );
+
+        // No translation available
+        if (total === 0) {
+            return null;
+        }
+
+        return this.#priorityMap;
+    }
+
+    /** Loads all JSON files from one provided directory */
+    async #loadFromDirectory({
+        directory,
+        moduleName,
+        priority,
+    }: LoadFromDirectoryParams): Promise<{ name?: string; translations: Translation[] }> {
+        console.log(`Babele | Fetching translation files from "${directory}"`);
+        const filesFromDirectory = async (directory: string) => {
+            if (!game.user.hasPermission("FILES_BROWSE" as unknown as UserPermission)) {
+                return game.settings.get("babele", "translationFiles").filter((path) => path.startsWith(directory));
+            }
+            const result = (await FilePicker.browse("data", directory, { extensions: [".json"] })) as {
+                files: string[];
+            };
+            return result.files;
+        };
+
+        const files = await filesFromDirectory(directory);
+        this.#allFiles.push(...files);
+        const fileContents = await this.#getJSONContent(files);
+        const moduleTranslations: Translation[] = [];
+        for (const [collection, translation] of fileContents) {
+            moduleTranslations.push(translation);
+            translation.collection ??= collection;
+            this.#addToPriorityMap(priority, translation);
+        }
+
+        return { name: moduleName, translations: moduleTranslations };
+    }
+
+    /** Extracts JSON content of provided files */
+    async #getJSONContent(files: string[]): Promise<[string, Translation][]> {
+        const collections: string[] = [];
+        const contents: Promise<Translation>[] = [];
+        for (const file of files) {
+            const response = await fetch(file);
+            if (response.ok) {
+                const collection = file.substring(file.lastIndexOf("/") + 1, file.lastIndexOf("."));
+                const pack = game.packs.get(collection);
+                if (collection.endsWith("_packs-folders") || isSupportedType(pack?.metadata.type)) {
+                    contents.push(response.json());
+                    collections.push(collection);
+                    console.log(`Babele | Loading translation for: ${collection}`);
+                }
+            }
+        }
+        const results = await Promise.allSettled(contents);
+        return results.flatMap((result, index) => {
+            const collection = collections[index];
+            if (result.status === "rejected") {
+                console.error(`Babel | Error parsing file for ${collection}:`, result.reason);
+                return [];
+            }
+            return [[collection, result.value]];
+        });
+    }
+
+    /** Groups translations by priority in a Map */
+    #addToPriorityMap(priority: number, translation: Translation | Translation[]): void {
+        if (this.#priorityMap.has(priority)) {
+            const current = this.#priorityMap.get(priority)!;
+            if (Array.isArray(translation)) {
+                current.push(...translation);
+            } else {
+                current.push(translation);
+            }
+        } else {
+            if (Array.isArray(translation)) {
+                this.#priorityMap.set(priority, translation);
+            } else {
+                this.#priorityMap.set(priority, [translation]);
+            }
+        }
+    }
+}
+
+interface BabeleLoaderParams {
+    lang: string;
+    modules: BabeleModule[];
+    systemTranslationsDir: string | null;
+}
+
+interface LoadFromDirectoryParams {
+    directory: string;
+    moduleName?: string;
+    priority: number;
+}
+
+export { BabeleLoader };

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,3 +1,6 @@
+import { Babele } from "@module";
+import { SupportedType } from "@module/babele/types.ts";
+
 function JSONstringifyOrder(obj: object): string {
     const allKeys: Set<string> = new Set();
     const idKeys: string[] = [];
@@ -30,4 +33,9 @@ function collectionFromUUID(uuid: unknown): string | null {
     return uuid.split(".").splice(1, 2).join(".");
 }
 
-export { isCompendiumUUID, collectionFromMetadata, collectionFromUUID, JSONstringifyOrder };
+function isSupportedType(type?: unknown): type is SupportedType {
+    if (typeof type !== "string") return false;
+    return Babele.SUPPORTED_PACKS.includes(type as SupportedType);
+}
+
+export { isCompendiumUUID, isSupportedType, collectionFromMetadata, collectionFromUUID, JSONstringifyOrder };

--- a/types/foundry/client/game.d.ts
+++ b/types/foundry/client/game.d.ts
@@ -47,7 +47,10 @@ declare global {
         };
 
         /** The game World which is currently active */
-        world: object;
+        world: {
+            id: string;
+            [key: string]: unknown;
+        };
 
         /** Localization support */
         i18n: Localization;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,7 @@ const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
                     { src: "LICENSE", dest: "." },
                     { src: "README.md", dest: "." },
                 ],
-            })
+            }),
         );
     } else {
         plugins.push(
@@ -58,7 +58,7 @@ const config = Vite.defineConfig(({ command, mode }): Vite.UserConfig => {
                         });
                     }
                 },
-            }
+            },
         );
     }
 


### PR DESCRIPTION
- Translations are now stored by the client in an `IndexedDB`.
- The stored translations are invalidated if the source module version changes.
- Stored translations of modules that are no longer active in the world are deleted automatically.
- The database can be emptied manually by calling `game.babele.clearDB()`.
- Zip support was removed as it is no longer needed to speed up translation loading.